### PR TITLE
Remove erroneous middleware

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -220,10 +220,6 @@ app.get('/*', function(req, res) {
   error(res, 404);
 });
 
-app.use(function(err, req, res) {
-  error(res, 500);
-});
-
 function error(res, code) {
   var codes = {
     '404' : 'Not found',


### PR DESCRIPTION
Express does not invoke middleware functions with an error object, so this
middleware does not have the intended effect.

In the production environment, the server logs contain over 6,600 of the
resulting error:

    TypeError: Object function next(err) {

(source code of function body omitted)

    } has no method 'status'
      at error (/mnt/jqf/server/index.js:233:7)
      at codes.404 (/mnt/jqf/server/index.js:224:3)
      at Layer.handle [as handle_request] (/mnt/jqf/node_modules/express/lib/router/layer.js:82:5)
      at trim_prefix (/mnt/jqf/node_modules/express/lib/router/index.js:271:13)
      at /mnt/jqf/node_modules/express/lib/router/index.js:238:9
      at Function.proto.process_params (/mnt/jqf/node_modules/express/lib/router/index.js:313:12)
      at /mnt/jqf/node_modules/express/lib/router/index.js:229:12
      at Function.match_layer (/mnt/jqf/node_modules/express/lib/router/index.js:296:3)
      at next (/mnt/jqf/node_modules/express/lib/router/index.js:190:10)
      at /mnt/jqf/node_modules/express/lib/router/index.js:215:18

Remove the middleware.